### PR TITLE
feat: add tracking for experience, project, and social link clicks

### DIFF
--- a/components/Experience.jsx
+++ b/components/Experience.jsx
@@ -3,6 +3,7 @@ import { Text, Heading, GridItem } from '@chakra-ui/react';
 import PropTypes from 'prop-types';
 import { LuExternalLink } from 'react-icons/lu';
 import Grid from './Grid';
+import { trackExperienceClick } from '../utils/analytics';
 
 export default function Experience({
   side,
@@ -26,6 +27,7 @@ export default function Experience({
           size="md"
           display="flex"
           alignItems="center"
+          onClick={href ? () => trackExperienceClick(title, href) : undefined}
         >
           {title}
           {href && <LuExternalLink style={{ marginLeft: '0.5rem' }} />}

--- a/components/Package.jsx
+++ b/components/Package.jsx
@@ -6,6 +6,7 @@ import { FaDownload } from 'react-icons/fa6';
 import Grid from './Grid';
 import fetchNpmDownloads from '../utils/npmDownloads';
 import fetchNpmVersion from '../utils/npmVersion';
+import { trackProjectClick } from '../utils/analytics';
 
 export default function Package({
   title,
@@ -56,6 +57,7 @@ export default function Package({
           size="md"
           display="flex"
           alignItems="center"
+          onClick={href ? () => trackProjectClick(title, href) : undefined}
         >
           {title}
           {href && <LuExternalLink style={{ marginLeft: '0.5rem' }} />}

--- a/components/SocialLinks.jsx
+++ b/components/SocialLinks.jsx
@@ -13,6 +13,7 @@ import {
 import { FaStackOverflow, FaLinkedin, FaGithub } from 'react-icons/fa';
 import React from 'react';
 import colors from '../utils/colors';
+import { trackSocialClick } from '../utils/analytics';
 
 export default function SocialLinks() {
   const bgColor = colors.black[500];
@@ -20,7 +21,15 @@ export default function SocialLinks() {
   return (
     <Grid templateColumns="repeat(5, 1fr)" mb={10} alignItems="flex-start">
       <GridItem>
-        <Link href="https://www.linkedin.com/in/ismail-mohmmd/">
+        <Link
+          href="https://www.linkedin.com/in/ismail-mohmmd/"
+          onClick={() =>
+            trackSocialClick(
+              'LinkedIn',
+              'https://www.linkedin.com/in/ismail-mohmmd/'
+            )
+          }
+        >
           <Flex align="center" gap="2">
             {' '}
             <FaLinkedin /> LinkedIn{' '}
@@ -30,7 +39,12 @@ export default function SocialLinks() {
       <GridItem>
         <Popover trigger="hover" placement="bottom" openDelay={200}>
           <PopoverTrigger>
-            <Link href="https://github.com/ismailmmd">
+            <Link
+              href="https://github.com/ismailmmd"
+              onClick={() =>
+                trackSocialClick('GitHub', 'https://github.com/ismailmmd')
+              }
+            >
               <Flex align="center" gap="2">
                 {' '}
                 <FaGithub /> Github{' '}
@@ -58,7 +72,15 @@ export default function SocialLinks() {
       <GridItem>
         <Popover trigger="hover" placement="bottom" openDelay={200}>
           <PopoverTrigger>
-            <Link href="https://stackoverflow.com/users/7962589/ismail">
+            <Link
+              href="https://stackoverflow.com/users/7962589/ismail"
+              onClick={() =>
+                trackSocialClick(
+                  'StackOverflow',
+                  'https://stackoverflow.com/users/7962589/ismail'
+                )
+              }
+            >
               <Flex align="center" gap="2">
                 {' '}
                 <FaStackOverflow /> StackOverflow{' '}

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -1,0 +1,24 @@
+/**
+ * Google Analytics event tracking utility
+ */
+const trackEvent = (action, category, label, value) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value,
+    });
+  }
+};
+
+export const trackSocialClick = (platform, url) => {
+  trackEvent('click', 'social_link', platform, url);
+};
+
+export const trackProjectClick = (projectName, url) => {
+  trackEvent('click', 'project_link', projectName, url);
+};
+
+export const trackExperienceClick = (companyName, url) => {
+  trackEvent('click', 'experience_link', companyName, url);
+};


### PR DESCRIPTION
## Description

  Analytics Events Structure:
  - Social links: social_link category with platform names
  - Project links: project_link category with project titles
  - Experience links: experience_link category with company names

  To view the data in Google Analytics:
  1. Go to Reports → Engagement → Events
  2. Look for events with categories: social_link, project_link, experience_link
  3. Use the event_label dimension to see specific link names
  4. Create custom reports to track click-through rates and popular links

## Commits

<!-- issue -->
